### PR TITLE
Development/refactor commands array

### DIFF
--- a/src/sonic_protocol/command_contracts/transducer_commands.py
+++ b/src/sonic_protocol/command_contracts/transducer_commands.py
@@ -81,7 +81,7 @@ set_gain = CommandContract(
         description="Command to set the gain of the transducer on the device."
     ),
     is_release=True,
-    tags=["gain", "transducer"]
+    tags=["gain", "transducer"],
 )
 
 get_gain = CommandContract(

--- a/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
+++ b/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
@@ -341,7 +341,7 @@ inline constexpr std::array<std::string_view, {len(string_identifiers)}> {string
         cpp_command_def = f"""
     CommandDef {{
         .code = CommandCode::{code.name},
-        .string_identifiers = std::span<std::string_view>{string_identifiers_cpp_var_name},
+        .string_identifiers = std::span<std::string_view>({string_identifiers_cpp_var_name}),
         .params = std::span<ParamDef>({param_defs_cpp_var_name})
     }}"""
         return cpp_command_def, param_def_cpp_var, string_identifiers_cpp

--- a/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
+++ b/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
@@ -1,4 +1,3 @@
-
 from enum import Enum, IntEnum
 from pathlib import Path
 from typing import Any, Generic, List, Literal, Tuple, TypeVar
@@ -101,6 +100,19 @@ def create_enum_to_string_conversions(enum: type[Enum]) -> str:
         assert(false);
     """
 
+def numpy_type_to_cpp_type(data_type: type) -> str:
+    if data_type is np.uint32:
+        return "uint32_t"
+    elif data_type is np.uint16:
+        return "uint16_t"
+    elif data_type is np.uint8:
+        return "uint8_t"
+    elif data_type is float:
+        return "float"
+    else:
+        return "uint32_t"
+        #raise ValueError(f"Unknown data type: {data_type}")
+
 @attrs.define()
 class ProtocolVersion:
     version: Version = attrs.field()
@@ -116,12 +128,17 @@ class FieldLimits(Generic[T]):
     maximum: T | None = attrs.field()
     allowed_values: List[T] | None = attrs.field()
     data_type: type[T] = attrs.field()
+    def cpp_data_type(self) -> str:
+        return numpy_type_to_cpp_type(self.data_type)
 
 class CppTransCompiler:
     def __init__(self):
-        self._var_id_counter: int = 0
+        self._field_limits_id_counter: int = 0
+        self._allowed_values_id_counter: int = 0
         self._field_limits_cache: dict[FieldLimits, str] = {}
-        self._param_definitions: set[CommandParamDef] = set()
+        self._param_definitions: dict[CommandParamDef, str] = {}
+        self._field_definitions: dict[AnswerFieldDef, str] = {}
+        self._allowed_values: dict[List[Any], str] = {}
 
     def generate_sonic_protocol_lib(self, output_dir: Path):
         # copy protocol definitions to output directory
@@ -191,139 +208,188 @@ class CppTransCompiler:
         )
 
     def generate_transpiled_protocol(self, protocol: Protocol, protocol_versions: List[ProtocolVersion], output_dir: Path): 
-        self._var_id_counter = 0
+        self._field_limits_id_counter = 0
         
         protocol_template_path = rs.files(sonic_protocol.cpp_trans_compiler).joinpath("sonic_protocol_lib").joinpath("generated_protocol.hpp")
         generated_protocol_path = output_dir / "generated_protocol.hpp"
         shutil.copyfile(str(protocol_template_path), generated_protocol_path)
 
         protocol_count = len(protocol_versions)
-        protocol_instances, protocol_return, max_command_count = self._transpile_protocols(protocol, protocol_versions)
+        protocol_instances, command_defs, answer_defs = self._transpile_protocols(protocol, protocol_versions)
+        param_defs = self._transpile_param_defs_from_cache()
+        field_defs = self._transpile_field_defs_from_cache()
         field_limits = self._transpile_field_limits_from_cache()
+        allowed_values = self._transpile_allowed_values_from_cache()
+        protocol_instances = ",\n".join(protocol_instances)
         self._inject_code_into_file(
             generated_protocol_path, 
             PROTOCOL_INSTANCES=protocol_instances,
-            PROTOCOLS=protocol_return, 
             PROTOCOL_COUNT=protocol_count, 
             FIELD_LIMITS=field_limits,
+            FIELD_DEFS = field_defs,
+            PARAM_DEFS = param_defs,
+            ALLOWED_VALUES = allowed_values,
+            COMMAND_DEFS = command_defs,
+            ANSWER_DEFS = answer_defs
         )
         
     def _inject_code_into_file(self, file_path: Path, **kwargs) -> None:
         with open(file_path, "r") as source_file:
             content = source_file.read()
         for key, value in kwargs.items():
+            if isinstance(value, list):
+                value = "\n".join(value)
             content = content.replace(f"/**/{key.upper()}/**/", str(value))
         with open(file_path, "w") as source_file:
             source_file.write(content)
 
-    def _transpile_protocols(self, protocol: Protocol, protocol_versions: List[ProtocolVersion]) -> Tuple[List[Tuple[str, str, str]], str, int]:
+    def _transpile_protocols(self, protocol: Protocol, protocol_versions: List[ProtocolVersion]) -> Tuple[List[str], List[str], List[str]]:
         protocol_builder = ProtocolBuilder(protocol)
         transpiled_protocols = []
         max_command_count = 0
         protocol_names = []
-        protocol_names_reference_lines = []
         for protocol_version in protocol_versions:
             protocol_names.append(f"protocol_{protocol_version.to_cpp_var_name()}")
-            protocol_names_reference_lines.append(f"&{protocol_names[-1]}")  # Add correct indentation
             command_lookup_table = protocol_builder.build(protocol_version.device_type, protocol_version.version, protocol_version.is_release)
             max_command_count = max(max_command_count, len(command_lookup_table))
             transpiled_protocols.append(self._transpile_command_contracts(protocol_version, command_lookup_table, protocol_names[-1]))
-        protocol_names_reference = ",\n        ".join(protocol_names_reference_lines)
-        return transpiled_protocols, protocol_names_reference, max_command_count
+        protocol_instances = []
+        command_defs = []
+        answer_defs = []
+
+        for protocol_def, command_defs_array, answer_defs_array in transpiled_protocols:
+            protocol_instances.append(protocol_def)
+            command_defs.append(command_defs_array)
+            answer_defs.append(answer_defs_array)
+        return protocol_instances, command_defs, answer_defs
 
     def _transpile_command_contracts(
-            self, protocol_version: ProtocolVersion, command_list: CommandLookUpTable, protocol_name) -> Tuple[str, str, str]:
+            self, protocol_version: ProtocolVersion, command_list: CommandLookUpTable, protocol_name: str) -> Tuple[str, str, str]:
         answer_defs = []
         command_defs = []
+        param_defs = []
+        string_identifiers = []
+        field_defs = []
         for code, command_lookup in sorted(command_list.items()):
             # In Transpile Command and answer def add single definition to a set an only return the names of the instances
-            command_defs.append(self._transpile_command_def(code, command_lookup.command_def))
-            answer_defs.append(self._transpile_answer_def(code, command_lookup.answer_def))
+            temp = self._transpile_command_def(code, command_lookup.command_def, protocol_name)
+            command_defs.append(temp[0])
+            param_defs.append(temp[1])
+            string_identifiers.append(temp[2])
+            temp = self._transpile_answer_def(code, command_lookup.answer_def, protocol_name)
+            answer_defs.append(temp[0])
+            field_defs.append(temp[1])
+        
         command_defs_array = f"""
-        constexpr std::array<CommandDef, {len(command_list)}> {protocol_name}_command_defs = {{
-            {", ".join(command_defs)}
-        }};
+{"".join(param_defs)}
+{"".join(string_identifiers)}
+inline constexpr std::array<CommandDef, {len(command_defs)}> {protocol_name}_command_defs = {{{", ".join(command_defs)}
+}};
         """
         answer_defs_array = f"""
-        constexpr std::array<AnswerDef, {len(command_list)}> {protocol_name}_answer_defs = {{
-            {", ".join(answer_defs)}
-        }};
-        """
+{"".join(field_defs)}
+inline constexpr std::array<AnswerDef, {len(answer_defs)}> {protocol_name}_answer_defs = {{{", ".join(answer_defs)}
+}};"""
         version = protocol_version.version
-        protocol_def = f"""
-constexpr Protocol {protocol_name} = Protocol {{
-    .version = Version {{
-        .major = {version.major},
-        .minor = {version.minor},
-        .patch = {version.patch},
-    }},
-    .device = DeviceType::{protocol_version.device_type.name},
-    .isRelease = {str(protocol_version.is_release).lower()},
-    .options = "",
-    .commands = std::span<CommandDef>({protocol_name}_answer_defs),
-    .answers = std::span<AnswerDef>({protocol_name}_answer_defs)
-}};
-
-        """
+        protocol_def = f"""    Protocol {{
+        .version = Version {{
+            .major = {version.major},
+            .minor = {version.minor},
+            .patch = {version.patch},
+        }},
+        .device = DeviceType::{protocol_version.device_type.name},
+        .isRelease = {str(protocol_version.is_release).lower()},
+        .options = "",
+        .commands = std::span<CommandDef>({protocol_name}_command_defs),
+        .answers = std::span<AnswerDef>({protocol_name}_answer_defs)
+    }}"""
         return (protocol_def, command_defs_array, answer_defs_array)
 
-    def _transpile_command_def(self, code: CommandCode, command_def: CommandDef) -> str:
+    def _transpile_command_def(self, code: CommandCode, command_def: CommandDef, protocol_name: str) -> Tuple[str, str, str]:
         assert isinstance(command_def.sonic_text_attrs, SonicTextCommandAttrs)
         string_identifiers = command_def.sonic_text_attrs.string_identifier
         string_identifiers = [string_identifiers] if isinstance(string_identifiers, str) else string_identifiers
-        param_def_cpp_var_name = f"{code.name}"
-        params = []
+        param_defs_cpp_var_name = protocol_name + f"_{code.name}_param_defs"
+        string_identifiers_cpp_var_name = protocol_name + f"_{code.name}_string_identifiers"
+        param_references = []
         if command_def.index_param is not None:
-            params.append(self._transpile_param_def(command_def.index_param, "INDEX"))
-            param_def_cpp_var_name += "_" + command_def.index_param.to_cpp_var_name()
+            if command_def.index_param in self._param_definitions:
+                param_references.append(self._param_definitions[command_def.index_param]) 
+            else:    
+                param_def_refernce_cpp_name = command_def.index_param.to_cpp_var_name() + "_INDEX"
+                self._param_definitions[command_def.index_param] = param_def_refernce_cpp_name
+                param_references.append(param_def_refernce_cpp_name)
         if command_def.setter_param is not None:
-            params.append(self._transpile_param_def(command_def.setter_param, "SETTER"))
-            param_def_cpp_var_name += "_" + command_def.setter_param.to_cpp_var_name()
-        param_def_cpp_var = f"""
-        constexpr std::array<ParamDef, {len(params)}> {param_def_cpp_var_name} = {{
-            {", ".join(params)}
-        }};
-        """
+            if command_def.setter_param in self._param_definitions:
+                param_references.append(self._param_definitions[command_def.setter_param]) 
+            else:    
+                param_def_refernce_cpp_name = command_def.setter_param.to_cpp_var_name() + "_SETTER"
+                self._param_definitions[command_def.setter_param] = param_def_refernce_cpp_name
+                param_references.append(param_def_refernce_cpp_name)
+        if param_references == []:
+            param_def_cpp_var = ""
+            param_defs_cpp_var_name = "EMPTY_PARAMS"
+        else:   
+            param_def_cpp_var = f"""
+inline constexpr std::array<ParamDef, {len(param_references)}> {param_defs_cpp_var_name} = {{
+    {",\n    ".join(param_references)}
+}};"""
+        string_identifiers_cpp = f"""
+inline constexpr std::array<std::string_view, {len(string_identifiers)}> {string_identifiers_cpp_var_name} = {convert_to_cpp_initializer_list(string_identifiers)};        
+"""
         cpp_command_def = f"""
-            CommandDef {{
-                .code = CommandCode::{code.name},
-                .string_identifiers = {convert_to_cpp_initializer_list(string_identifiers)},
-                .params = std::span<ParamDef>({code.name}_param_defs)
-            }}
-        """
-        return cpp_command_def
+    CommandDef {{
+        .code = CommandCode::{code.name},
+        .string_identifiers = std::span<std::stringview>{string_identifiers_cpp_var_name},
+        .params = std::span<ParamDef>({param_defs_cpp_var_name})
+    }}"""
+        return cpp_command_def, param_def_cpp_var, string_identifiers_cpp
 
-    def _transpile_param_def(self, param_def: CommandParamDef, param_type: Literal["SETTER", "INDEX"]) -> str:
+    def _transpile_param_def(self, param_def: CommandParamDef, var_name: str) -> str:
+        if "SETTER" in var_name:
+            param_type = "SETTER"
+        elif "INDEX" in var_name:
+            param_type = "INDEX"
+        else:
+            assert False, f"Unknown param type: {var_name}"
         cpp_param_def: str = f"""
-            ParamDef {{
-                .field_name = {convert_to_cpp_field_name(param_def.name)},
-                .param_type = ParamType::{param_type},
-                .field_type = {self._transpile_field_type(param_def.param_type)}
-            }}
-        """
+inline constexpr ParamDef {var_name} = {{
+    .field_name = {convert_to_cpp_field_name(param_def.name)},
+    .param_type = ParamType::{param_type},
+    .field_type = {self._transpile_field_type(param_def.param_type)}
+}};"""
         return cpp_param_def
 
-    def _transpile_answer_def(self, code: CommandCode, answer_def: AnswerDef) -> str:
-        transpiled_fields = [self._transpile_answer_field(field) for field in answer_def.fields]
+    def _transpile_answer_def(self, code: CommandCode, answer_def: AnswerDef, protocol_name: str) -> Tuple[str,str]:
+        transpiled_field_references = []
+        for field in answer_def.fields:
+            if field in self._field_definitions:
+                transpiled_field_references.append(self._field_definitions[field])
+            else:  
+                field_def_cpp_var_name = field.to_cpp_var_name()
+                self._field_definitions[field] = field_def_cpp_var_name
+                transpiled_field_references.append(field_def_cpp_var_name)    
+        answer_fields_cpp_var_name = protocol_name + f"_{code.name}_answer_fields"
+        param_def_array_cpp_var = f"""
+inline constexpr std::array<AnswerFieldDef, {len(transpiled_field_references)}> {answer_fields_cpp_var_name} = {{
+    {",\n    ".join(transpiled_field_references)}
+}};"""
         cpp_answer_def = f"""
-            AnswerDef {{
-                .code = CommandCode::{code.name},
-                .fields = etl::array<AnswerFieldDef, MAX_ANSWER_FIELDS>{{ 
-                    {", ".join(transpiled_fields)} 
-                }}
-            }}
-        """
-        return cpp_answer_def
+    AnswerDef {{
+        .code = CommandCode::{code.name},
+        .fields = std::span<AnswerFieldDef>({answer_fields_cpp_var_name})
+    }}"""
+        return cpp_answer_def, param_def_array_cpp_var
 
-    def _transpile_answer_field(self, field: AnswerFieldDef) -> str:
+    def _transpile_answer_field(self, field: AnswerFieldDef, var_name: str) -> str:
         assert isinstance(field.sonic_text_attrs, SonicTextAnswerFieldAttrs)
         cpp_answer_field_def: str = f"""
-            AnswerFieldDef {{
-                .name = {convert_to_cpp_field_name(field.field_name)},
-                .type = {self._transpile_field_type(field.field_type)},
-                .prefix = "{field.sonic_text_attrs.prefix}",
-                .postfix = "{field.sonic_text_attrs.postfix}"
-            }}
+inline constexpr AnswerFieldDef {var_name} = {{
+    .name = {convert_to_cpp_field_name(field.field_name)},
+    .type = {self._transpile_field_type(field.field_type)},
+    .prefix = "{field.sonic_text_attrs.prefix}",
+    .postfix = "{field.sonic_text_attrs.postfix}"
+}};
         """
         return cpp_answer_field_def
 
@@ -340,20 +406,17 @@ constexpr Protocol {protocol_name} = Protocol {{
         if field_limits in self._field_limits_cache:
             cpp_limits_var: str = self._field_limits_cache[field_limits]
         else:
-            self._var_id_counter += 1
-            cpp_limits_var: str = f"limits_{self._var_id_counter}"
+            self._field_limits_id_counter += 1
+            cpp_limits_var: str = f"limits_{self._field_limits_id_counter}"
             self._field_limits_cache[field_limits] = cpp_limits_var
 
-        cpp_field_type_def: str = f"""
-            FieldTypeDef {{
-                .type = {convert_to_enum_data_type(field_type.field_type)},
-                .converter_reference = ConverterReference::{field_type.converter_ref.name},
-                .limits = static_cast<const void *>(&{cpp_limits_var}),
-                .si_unit = {f"SIUnit::{field_type.si_unit.name}" if field_type.si_unit is not None else CPP_NULLOPT},
-                .si_prefix = {f"SIPrefix::{field_type.si_prefix.name}" if field_type.si_prefix is not None else CPP_NULLOPT}
-            }}
-        """
-        
+        cpp_field_type_def: str = f"""FieldTypeDef {{
+        .type = {convert_to_enum_data_type(field_type.field_type)},
+        .converter_reference = ConverterReference::{field_type.converter_ref.name},
+        .limits = static_cast<const void *>(&{cpp_limits_var}),
+        .si_unit = {f"SIUnit::{field_type.si_unit.name}" if field_type.si_unit is not None else CPP_NULLOPT},
+        .si_prefix = {f"SIPrefix::{field_type.si_prefix.name}" if field_type.si_prefix is not None else CPP_NULLOPT}
+    }}""" 
         return cpp_field_type_def
 
     def _transpile_field_limits_from_cache(self) -> str:
@@ -361,26 +424,44 @@ constexpr Protocol {protocol_name} = Protocol {{
         for field_limits, var_name in self._field_limits_cache.items():
             transpilation_output += self._transpile_field_limits(field_limits, var_name)
         return transpilation_output
+    
+    def _transpile_param_defs_from_cache(self) -> str:
+        transpilation_output = ""
+        for param_def, var_name in self._param_definitions.items():
+            transpilation_output += self._transpile_param_def(param_def, var_name)
+        return transpilation_output
+    def _transpile_field_defs_from_cache(self) -> str:
+        transpilation_output = ""
+        for field, var_name in self._field_definitions.items():
+            transpilation_output += self._transpile_answer_field(field, var_name)
+        return transpilation_output
+    
+    def _transpile_allowed_values_from_cache(self) -> str:
+        transpilation_output = ""
+        for allowed_values, var_name in self._allowed_values.items():
+            transpilation_output += f"constexpr std::array<{numpy_type_to_cpp_type(type(allowed_values))}> {var_name} = {convert_to_cpp_initializer_list(allowed_values)};\n"
+        return transpilation_output
 
     def _transpile_field_limits(self, field_limits: FieldLimits, var_name: str) -> str:
-        allowed_values = convert_to_cpp_initializer_list(field_limits.allowed_values) if field_limits.allowed_values else CPP_NULLOPT  
-        data_type = "uint32_t" # TODO choose default data type, how to handle str and bool and enums
-        if field_limits.data_type is np.uint32:
-            data_type = "uint32_t"
-        elif field_limits.data_type is np.uint16:
-            data_type = "uint16_t"
-        elif field_limits.data_type is np.uint8:
-            data_type = "uint8_t"
-        elif field_limits.data_type is float:
-            data_type = "float"
+        if field_limits.allowed_values is None:
+            allowed_values_ref = CPP_NULLOPT
+        else:
+            if field_limits.allowed_values in self._allowed_values:
+                allowed_values_ref = self._allowed_values[field_limits.allowed_values]
+            else:
+                num_allowed_values = len(field_limits.allowed_values)
+                allowed_values_ref = f"{var_name}_{num_allowed_values}_allowed_values"
+                self._allowed_values[field_limits.allowed_values] = allowed_values_ref
+            allowed_values_ref = f"std::span({allowed_values_ref})"
+        
         cpp_field_limits: str = f"""
-            FieldLimits<{data_type}> {{
-                .min = {nullopt_if_none(field_limits.minimum)},
-                .max = {nullopt_if_none(field_limits.maximum)},
-                .allowed_values = {allowed_values}
-            }}
-        """ 
-        return f"constexpr auto {var_name} {{ {cpp_field_limits} }};\n"
+    FieldLimits<{field_limits.cpp_data_type()}> {{
+        .min = {nullopt_if_none(field_limits.minimum)},
+        .max = {nullopt_if_none(field_limits.maximum)},
+        .allowed_values = {allowed_values_ref}
+    }}
+""" 
+        return f"inline constexpr auto {var_name} {{ {cpp_field_limits} }};\n"
 
 
 

--- a/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
+++ b/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
@@ -302,8 +302,8 @@ inline constexpr std::array<AnswerDef, {len(answer_defs)}> {answer_defs_cpp_var_
         .device = DeviceType::{protocol_version.device_type.name},
         .isRelease = {str(protocol_version.is_release).lower()},
         .options = "",
-        .commands = std::span<CommandDef>({command_defs_cpp_var_name}.data(), {command_defs_cpp_var_name}.size()),
-        .answers = std::span<AnswerDef>({answer_defs_cpp_var_name}.data(), {answer_defs_cpp_var_name}.size())
+        .commands = std::span<const CommandDef>({command_defs_cpp_var_name}.data(), {command_defs_cpp_var_name}.size()),
+        .answers = std::span<const AnswerDef>({answer_defs_cpp_var_name}.data(), {answer_defs_cpp_var_name}.size())
     }}"""
         return (protocol_def, command_defs_array, answer_defs_array)
 
@@ -343,8 +343,8 @@ inline constexpr std::array<std::string_view, {len(string_identifiers)}> {string
         cpp_command_def = f"""
     CommandDef {{
         .code = CommandCode::{code.name},
-        .string_identifiers = std::span<std::string_view>({string_identifiers_cpp_var_name}.data(), {string_identifiers_cpp_var_name}.size()),
-        .params = std::span<ParamDef>({param_defs_cpp_var_name}.data(), {param_defs_cpp_var_name}.size())
+        .string_identifiers = std::span<const std::string_view>({string_identifiers_cpp_var_name}.data(), {string_identifiers_cpp_var_name}.size()),
+        .params = std::span<const ParamDef>({param_defs_cpp_var_name}.data(), {param_defs_cpp_var_name}.size())
     }}"""
         return cpp_command_def, param_def_cpp_var, string_identifiers_cpp
 
@@ -381,7 +381,7 @@ inline constexpr std::array<AnswerFieldDef, {len(transpiled_field_references)}> 
         cpp_answer_def = f"""
     AnswerDef {{
         .code = CommandCode::{code.name},
-        .fields = std::span<AnswerFieldDef>({answer_fields_cpp_var_name}.data(), {answer_fields_cpp_var_name}.size())
+        .fields = std::span<const AnswerFieldDef>({answer_fields_cpp_var_name}.data(), {answer_fields_cpp_var_name}.size())
     }}"""
         return cpp_answer_def, param_def_array_cpp_var
 
@@ -456,7 +456,7 @@ inline constexpr AnswerFieldDef {var_name} = {{
                 num_allowed_values = len(field_limits.allowed_values)
                 allowed_values_ref = f"{var_name}_{num_allowed_values}_allowed_values"
                 self._allowed_values[field_limits.allowed_values] = allowed_values_ref
-            allowed_values_ref = f"std::span<{field_limits.cpp_data_type()}>({allowed_values_ref}.data(), {allowed_values_ref}.size())"
+            allowed_values_ref = f"std::span<const {field_limits.cpp_data_type()}>({allowed_values_ref}.data(), {allowed_values_ref}.size())"
         
         cpp_field_limits: str = f"""
     FieldLimits<{field_limits.cpp_data_type()}> {{

--- a/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
+++ b/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
@@ -341,7 +341,7 @@ inline constexpr std::array<std::string_view, {len(string_identifiers)}> {string
         cpp_command_def = f"""
     CommandDef {{
         .code = CommandCode::{code.name},
-        .string_identifiers = std::span<std::stringview>{string_identifiers_cpp_var_name},
+        .string_identifiers = std::span<std::string_view>{string_identifiers_cpp_var_name},
         .params = std::span<ParamDef>({param_defs_cpp_var_name})
     }}"""
         return cpp_command_def, param_def_cpp_var, string_identifiers_cpp

--- a/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
+++ b/src/sonic_protocol/cpp_trans_compiler/cpp_trans_compiler.py
@@ -330,9 +330,10 @@ inline constexpr std::array<AnswerDef, {len(answer_defs)}> {protocol_name}_answe
             param_def_cpp_var = ""
             param_defs_cpp_var_name = "EMPTY_PARAMS"
         else:   
+            formatted_references = ",\n    ".join(param_references)
             param_def_cpp_var = f"""
 inline constexpr std::array<ParamDef, {len(param_references)}> {param_defs_cpp_var_name} = {{
-    {",\n    ".join(param_references)}
+    {formatted_references}
 }};"""
         string_identifiers_cpp = f"""
 inline constexpr std::array<std::string_view, {len(string_identifiers)}> {string_identifiers_cpp_var_name} = {convert_to_cpp_initializer_list(string_identifiers)};        
@@ -370,9 +371,10 @@ inline constexpr ParamDef {var_name} = {{
                 self._field_definitions[field] = field_def_cpp_var_name
                 transpiled_field_references.append(field_def_cpp_var_name)    
         answer_fields_cpp_var_name = protocol_name + f"_{code.name}_answer_fields"
+        formatted_transpiled_field_references = ",\n    ".join(transpiled_field_references)
         param_def_array_cpp_var = f"""
 inline constexpr std::array<AnswerFieldDef, {len(transpiled_field_references)}> {answer_fields_cpp_var_name} = {{
-    {",\n    ".join(transpiled_field_references)}
+    {formatted_transpiled_field_references}
 }};"""
         cpp_answer_def = f"""
     AnswerDef {{

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/generated_protocol.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/generated_protocol.hpp
@@ -10,6 +10,7 @@ namespace sonic_protocol_lib {
 
 #define FIELD_LIMITS
 /**/FIELD_LIMITS/**/ // the python script will replace this
+#undef FIELD_LIMITS
 
 #define PROTOCOL_COUNT 0
 consteval std::size_t protocol_count() {
@@ -17,8 +18,25 @@ consteval std::size_t protocol_count() {
 }
 #undef PROTOCOL_COUNT
 
+#define ALLOWED_VALUES
+/**/ALLOWED_VALUES/**/ // the python script will replace this
+#undef ALLOWED_VALUES
+
+#define FIELD_DEFS
+/**/FIELD_DEFS/**/ // the python script will replace this
+#undef FIELD_DEFS
+
+#define COMMAND_DEFS
+/**/COMMAND_DEFS/**/ // the python script will replace this
+#undef COMMAND_DEFS
+
+#define ANSWER_CONTRACTS
+/**/ANSWER_CONTRACTS/**/ // the python script will replace this
+#undef ANSWER_CONTRACTS
+
 #define PROTOCOL_INSTANCES
 /**/PROTOCOL_INSTANCES/**/ // the python script will replace this
+#undef PROTOCOL_INSTANCES
 
 #define PROTOCOLS {}
 consteval std::array<const IProtocol*, protocol_count()> protocols() {

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/generated_protocol.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/generated_protocol.hpp
@@ -26,23 +26,27 @@ consteval std::size_t protocol_count() {
 /**/FIELD_DEFS/**/ // the python script will replace this
 #undef FIELD_DEFS
 
+#define PARAM_DEFS
+/**/PARAM_DEFS/**/ // the python script will replace this
+#undef PARAM_DEFS
+
 #define COMMAND_DEFS
-/**/COMMAND_DEFS/**/ // the python script will replace this
+inline constexpr std::array<ParamDef, 0> EMPTY_PARAMS{};/**/COMMAND_DEFS/**/ // the python script will replace this
 #undef COMMAND_DEFS
 
-#define ANSWER_CONTRACTS
-/**/ANSWER_CONTRACTS/**/ // the python script will replace this
-#undef ANSWER_CONTRACTS
+#define ANSWER_DEFS
+/**/ANSWER_DEFS/**/ // the python script will replace this
+#undef ANSWER_DEFS
 
 #define PROTOCOL_INSTANCES
+constexpr std::array<Protocol, protocol_count()> protocol_instances = {
 /**/PROTOCOL_INSTANCES/**/ // the python script will replace this
+};
 #undef PROTOCOL_INSTANCES
 
-#define PROTOCOLS {}
-consteval std::array<const IProtocol*, protocol_count()> protocols() {
-    /**/PROTOCOLS/**/; // the python script will replace this
+consteval std::span<Protocol> protocols() {
+    return std::span<Protocol>(protocol_instances);
 }
-#undef PROTOCOLS
 
 
 }

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/generated_protocol.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/generated_protocol.hpp
@@ -44,8 +44,8 @@ constexpr std::array<Protocol, protocol_count()> protocol_instances = {
 };
 #undef PROTOCOL_INSTANCES
 
-consteval std::span<Protocol> protocols() {
-    return std::span<Protocol>(protocol_instances);
+consteval std::span<const Protocol> protocols() {
+    return std::span<const Protocol>(protocol_instances);
 }
 
 

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/answer_def.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/answer_def.hpp
@@ -2,14 +2,14 @@
 #include <initializer_list>
 #include "answer_field_def.hpp"
 #include "command_code.hpp"
-#include "etl/array.h"
+#include <span>
 
 namespace sonic_protocol_lib {
 
 constexpr std::size_t MAX_ANSWER_FIELDS = 20;
 struct AnswerDef {
     CommandCode code{CommandCode::INVALID};
-    etl::array<AnswerFieldDef, MAX_ANSWER_FIELDS> fields;
+    std::span<AnswerFieldDef> fields;
 };
 
 }

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/answer_def.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/answer_def.hpp
@@ -9,7 +9,7 @@ namespace sonic_protocol_lib {
 constexpr std::size_t MAX_ANSWER_FIELDS = 20;
 struct AnswerDef {
     CommandCode code{CommandCode::INVALID};
-    std::span<AnswerFieldDef> fields;
+    std::span<const AnswerFieldDef> fields;
 };
 
 }

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/command_def.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/command_def.hpp
@@ -10,8 +10,8 @@ constexpr std::size_t MAX_PARAMS = 20;
 constexpr std::size_t MAX_STRING_IDENTIFIERS = 10;
 struct CommandDef {
     CommandCode code{CommandCode::INVALID};
-    std::span<std::string_view> string_identifiers;
-    std::span<ParamDef> params;
+    std::span<const std::string_view> string_identifiers;
+    std::span<const ParamDef> params;
 };
 
 }

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/command_def.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/command_def.hpp
@@ -3,7 +3,6 @@
 #include <string_view>
 #include "param_def.hpp"
 #include "command_code.hpp"
-#include <etl/array.h>
 
 namespace sonic_protocol_lib {
 
@@ -11,8 +10,8 @@ constexpr std::size_t MAX_PARAMS = 20;
 constexpr std::size_t MAX_STRING_IDENTIFIERS = 10;
 struct CommandDef {
     CommandCode code{CommandCode::INVALID};
-    etl::array<std::string_view, MAX_STRING_IDENTIFIERS> string_identifiers;
-    etl::array<ParamDef, MAX_PARAMS> params;
+    std::span<std::string_view> string_identifiers;
+    std::span<ParamDef> params;
 };
 
 }

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/field_type_def.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/field_type_def.hpp
@@ -43,7 +43,7 @@ template <typename T>
 struct FieldLimits {
     std::optional<T> min;
     std::optional<T> max;
-    std::optional<std::span<T>> allowed_values;
+    std::optional<std::span<const T>> allowed_values;
 };
 
 struct FieldTypeDef {

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/field_type_def.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/field_type_def.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 
 #include "si_units.hpp"
-#include <etl/array.h>
+#include <span>
 
 namespace sonic_protocol_lib {
 
@@ -43,7 +43,7 @@ template <typename T>
 struct FieldLimits {
     std::optional<T> min;
     std::optional<T> max;
-    std::optional<etl::array<T, MAX_ALLOWED_VALUES>> allowed_values;
+    std::optional<std::span<T>> allowed_values;
 };
 
 struct FieldTypeDef {

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/protocol.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/protocol.hpp
@@ -5,7 +5,6 @@
 #include "answer_def.hpp"
 #include "command_def.hpp"
 #include "enums.hpp"
-#include "etl/array.h"
 
 namespace sonic_protocol_lib {
 
@@ -17,51 +16,12 @@ struct Version {
 
 class IProtocol {
 public:
-    virtual ~IProtocol() = default;
-    virtual Version getVersion() const = 0;
-    virtual DeviceType getDevice() const = 0;
-    virtual bool getIsRelease() const = 0;
-    virtual std::string_view getOptions() const = 0;
-    virtual std::span<const CommandDef> getCommandsSpan() const = 0;
-    virtual std::span<const AnswerDef> getAnswersSpan() const = 0;
-};
-
-template <size_t CommandCount, size_t AnswerCount>
-struct ProtocolDataTemplated {
     Version version;
     DeviceType device;
     bool isRelease;
     std::string_view options;
-    etl::array<CommandDef, CommandCount> commands;
-    etl::array<AnswerDef, AnswerCount> answers;
+    std::span<CommandDef> commands;
+    std::span<AnswerDef> answers;
 };
-
-template <size_t CommandCount, size_t AnswerCount>
-class ProtocolTemplated : public IProtocol {
-private:
-    ProtocolDataTemplated<CommandCount, AnswerCount> data;
-
-public:
-    constexpr ProtocolTemplated(ProtocolDataTemplated<CommandCount, AnswerCount> data)
-        : data(data) {}
-    constexpr ~ProtocolTemplated() = default;
-    Version getVersion() const override { return data.version; }
-    DeviceType getDevice() const override { return data.device; }
-    bool getIsRelease() const override { return data.isRelease; }
-    std::string_view getOptions() const override { return data.options; }
-    std::span<const CommandDef> getCommandsSpan() const override {
-        return std::span<const CommandDef>(data.commands.data(), data.commands.size());
-    }
-    std::span<const AnswerDef> getAnswersSpan() const override {
-        return std::span<const AnswerDef>(data.answers.data(), data.answers.size());
-    }
-    
-};
-
-
-template<size_t Count>
-using Protocol = ProtocolTemplated<Count, Count>;
-template<size_t Count>
-using ProtocolData = ProtocolDataTemplated<Count, Count>;
 
 }

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/protocol.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/protocol.hpp
@@ -20,8 +20,8 @@ public:
     DeviceType device;
     bool isRelease;
     std::string_view options;
-    std::span<CommandDef> commands;
-    std::span<AnswerDef> answers;
+    std::span<const CommandDef> commands;
+    std::span<const AnswerDef> answers;
 };
 
 }

--- a/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/protocol.hpp
+++ b/src/sonic_protocol/cpp_trans_compiler/sonic_protocol_lib/include/sonic_protocol_lib/protocol.hpp
@@ -14,7 +14,7 @@ struct Version {
   uint8_t patch{0};
 };
 
-class IProtocol {
+class Protocol {
 public:
     Version version;
     DeviceType device;

--- a/src/sonic_protocol/defs.py
+++ b/src/sonic_protocol/defs.py
@@ -189,7 +189,6 @@ class FieldType(Generic[T]):
     si_prefix: Optional[SIPrefix] = attrs.field(default=None)
     converter_ref: ConverterType = attrs.field(default=ConverterType.PRIMITIVE) #! converters are defined in the code and the protocol only references to them
 
-
 def to_field_type(value: Any) -> FieldType:
     if isinstance(value, FieldType):
         return value
@@ -200,6 +199,22 @@ class CommandParamDef():
     name: EFieldName = attrs.field(converter=EFieldName)
     param_type: FieldType = attrs.field(converter=to_field_type)
     user_manual_attrs: AttrsExport[UserManualAttrs] = attrs.field(default=UserManualAttrs())
+    def __hash__(self):
+        return hash((self.name, self.param_type.field_type, self.param_type.converter_ref, self.param_type.si_unit, self.param_type.si_prefix, self.param_type.max_value, self.param_type.min_value))
+
+    def to_cpp_var_name(self):
+        si_unit_name = self.param_type.si_unit.name.lower() if self.param_type.si_unit else "none"
+        si_prefix_name = self.param_type.si_prefix.name.lower() if self.param_type.si_prefix else "none"
+        if isinstance(self.param_type.min_value, DeviceParamConstantType):
+            min_value_name = self.param_type.min_value.name.lower()
+        else:
+            min_value_name = str(self.param_type.min_value) if self.param_type.min_value else "none"
+        if isinstance(self.param_type.max_value, DeviceParamConstantType):
+            max_value_name = self.param_type.max_value.name.lower()
+        else:
+            max_value_name = str(self.param_type.max_value) if self.param_type.max_value else "none"
+        var_name = f"{self.name.value.lower()}_{self.param_type.field_type.__name__.lower()}_{si_unit_name}_{si_prefix_name}_{min_value_name}_{max_value_name}"
+        return var_name
 
 @attrs.define(auto_attribs=True)
 class CommandDef():

--- a/src/sonic_protocol/defs.py
+++ b/src/sonic_protocol/defs.py
@@ -238,6 +238,29 @@ class AnswerFieldDef():
     field_type: FieldType = attrs.field(converter=to_field_type)
     user_manual_attrs: AttrsExport[UserManualAttrs] = attrs.field(default=UserManualAttrs())
     sonic_text_attrs: AttrsExport[SonicTextAnswerFieldAttrs] = attrs.field(default=SonicTextAnswerFieldAttrs())
+    def __hash__(self):
+        return hash((self.field_name, self.field_type.field_type, self.field_type.converter_ref, self.field_type.si_unit, self.field_type.si_prefix, self.field_type.max_value, self.field_type.min_value))
+    def to_cpp_var_name(self):
+        si_unit_name = self.field_type.si_unit.name.lower() if self.field_type.si_unit else "none"
+        si_prefix_name = self.field_type.si_prefix.name.lower() if self.field_type.si_prefix else "none"
+        if isinstance(self.field_type.min_value, DeviceParamConstantType):
+            min_value_name = self.field_type.min_value.name.lower()
+        else:
+            min_value_name = str(self.field_type.min_value) if self.field_type.min_value else "none"
+        if isinstance(self.field_type.max_value, DeviceParamConstantType):
+            max_value_name = self.field_type.max_value.name.lower()
+        else:
+            max_value_name = str(self.field_type.max_value) if self.field_type.max_value else "none"
+        if isinstance(self.sonic_text_attrs, SonicTextAnswerFieldAttrs):
+            # Remove characters that are not allowed in cpp variable names
+            prefix = ''.join(e for e in self.sonic_text_attrs.prefix if e.isalnum())
+            postfix = ''.join(e for e in self.sonic_text_attrs.postfix if e.isalnum())
+        else:
+            prefix = "none"
+            postfix = "none"
+        var_name = f"{self.field_name.value.lower()}_{self.field_type.field_type.__name__.lower()}_{si_unit_name}_{si_prefix_name}_{min_value_name}_{max_value_name}_{prefix}_{postfix}"
+        return var_name
+
 
 
 @attrs.define(auto_attribs=True)


### PR DESCRIPTION
Everything is stored as inline constexpr and the variable names are uniquely create by the trans compiler. All the protocol classes use spans. There might be some stuff that could be optimized, but I dont have the BOCK for that right now. It works!